### PR TITLE
filter added

### DIFF
--- a/src/resolvers/Query.js
+++ b/src/resolvers/Query.js
@@ -1,6 +1,16 @@
-const feed = (parent, args, context, info) => (
-    context.prisma.links()
-)
+const feed = async (parent, args, context, info) => {
+    const where = args.filter ? {
+        OR: [
+            { description_contains: args.filter },
+            { url_contains: args.filter }
+        ],
+    } : {}
+    
+    const links = await context.prisma.links({
+        where
+    })
+    return links
+}
 
 module.exports = {
     feed,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,6 +1,6 @@
 type Query {
   info: String!
-  feed: [Link!]!
+  feed(filter: String): [Link!]!
 }
 
 type Mutation {


### PR DESCRIPTION
If no filter string is provided, then the where object will be just an empty object and no filtering conditions will be applied by the Prisma engine when it returns the response for the links query.

In case there is a filter carried by the incoming args, you’re constructing a where object that expresses our two filter conditions from above. This where argument is used by Prisma to filter out those Link elements that don’t adhere to the specified conditions.